### PR TITLE
Disables quotation for all values

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,9 +74,13 @@ func initArgParser() {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	// verbose level
+	// JSON formatter
 	if opts.Log.Json {
 		log.SetFormatter(&log.JSONFormatter{})
+	} else {
+		log.SetFormatter(&log.TextFormatter{
+			DisableQuote: true,
+		})
 	}
 }
 


### PR DESCRIPTION
Disabling of quotations produces a much nicer output and \n are replaced with real newlines. This is needed to get nice output to e.g journald or other cases where the output is not a TTY.