### PR TITLE
Add metric for cronjob next/prev time

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -7,6 +7,8 @@ var (
 	prometheusMetricTaskRunCount    *prometheus.CounterVec
 	prometheusMetricTaskRunResult   *prometheus.GaugeVec
 	prometheusMetricTaskRunTime     *prometheus.GaugeVec
+	prometheusMetricTaskRunPrevTs   *prometheus.GaugeVec
+	prometheusMetricTaskRunNextTs   *prometheus.GaugeVec
 	prometheusMetricTaskRunDuration *prometheus.GaugeVec
 )
 
@@ -55,6 +57,24 @@ func initMetrics() {
 		[]string{"cronSpec", "cronUser", "cronCommand"},
 	)
 	prometheus.MustRegister(prometheusMetricTaskRunDuration)
+
+	prometheusMetricTaskRunNextTs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gocrond_task_run_next_time",
+			Help: "gocrond task next run ts",
+		},
+		[]string{"cronSpec", "cronUser", "cronCommand"},
+	)
+	prometheus.MustRegister(prometheusMetricTaskRunNextTs)
+
+	prometheusMetricTaskRunPrevTs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gocrond_task_run_prev_time",
+			Help: "gocrond task prev run ts",
+		},
+		[]string{"cronSpec", "cronUser", "cronCommand"},
+	)
+	prometheus.MustRegister(prometheusMetricTaskRunPrevTs)
 }
 
 func resetMetrics() {
@@ -63,4 +83,6 @@ func resetMetrics() {
 	prometheusMetricTaskRunResult.Reset()
 	prometheusMetricTaskRunTime.Reset()
 	prometheusMetricTaskRunDuration.Reset()
+	prometheusMetricTaskRunNextTs.Reset()
+	prometheusMetricTaskRunPrevTs.Reset()
 }

--- a/parser.go
+++ b/parser.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,6 +36,7 @@ type CrontabEntry struct {
 	Env         []string
 	Shell       string
 	CrontabPath string
+	EntryId     cron.EntryID
 }
 
 type Parser struct {
@@ -63,6 +65,10 @@ func NewCronjobSystemParser(path string) (*Parser, error) {
 	}
 
 	return p, nil
+}
+
+func (e *CrontabEntry) SetEntryId(eid cron.EntryID) {
+	(*e).EntryId = eid
 }
 
 // Parse crontab


### PR DESCRIPTION
Expose metrics about job next run time and prev expect run time. We can add SLA miss alert by using those two metrics.