### PR TITLE
Updated to Go-Lang 1.21 as builder to fix 3 CVE's from Docker Scout

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,7 +1,7 @@
 #############################################
 # Build
 #############################################
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as build
 
 RUN apk upgrade --no-cache --force
 RUN apk add --update build-base make git

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,7 +1,7 @@
 #############################################
 # Build
 #############################################
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as build
 
 RUN apk upgrade --no-cache --force
 RUN apk add --update build-base make git

--- a/Dockerfile.develop
+++ b/Dockerfile.develop
@@ -1,4 +1,4 @@
-FROM golang:1.20-buster
+FROM golang:1.21-buster
 
 # Install tools
 RUN apt-get update \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 #############################################
 # Build
 #############################################
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine as build
+FROM --platform=$BUILDPLATFORM golang:1.21-alpine as build
 
 RUN apk upgrade --no-cache --force
 RUN apk add --update build-base make git


### PR DESCRIPTION
No code / structure changes, the only change is using a newer version of the golang-alpine base container that fixes 3 CVE reports by Docker Scout.

https://scout.docker.com/vulnerabilities/id/CVE-2023-29403
https://scout.docker.com/vulnerabilities/id/CVE-2023-29409
https://scout.docker.com/vulnerabilities/id/CVE-2023-29406

The first one is a ranked high, the other two as medium.

All the tests are green, and I did run a tagged release of the docker images. Those images can be found at https://hub.docker.com/r/renebakx/go-crond

